### PR TITLE
Update README to refelect travi build url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,8 +43,8 @@ Documentation
 Build Status
 ============
 
-.. image:: https://travis-ci.org/toastdriven/django-haystack.svg?branch=master
-   :target: https://travis-ci.org/toastdriven/django-haystack
+.. image:: https://travis-ci.org/django-haystack/django-haystack.svg?branch=master
+   :target: https://travis-ci.org/django-haystack/django-haystack
 
 Requirements
 ============


### PR DESCRIPTION
I think the repo got changed at some point and the old project referenced at travisci doesn't exist anymore...
